### PR TITLE
Fix HTML leakage in markdown.inline

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ blockRenderer.image  = function (href, title, text) {
 inlineRenderer.urltransform = function (url) { return false }
 inlineRenderer.link = function (href, title, text) { return unquote(text) }
 inlineRenderer.image  = function (href, title, text) { return unquote(text) }
-inlineRenderer.code = function(code, lang, escaped) { return unquote(code) }
+inlineRenderer.code = function(code, lang, escaped) { return escaped ? code : quote(code) }
 inlineRenderer.blockquote = function(quote) { return unquote(quote) }
 inlineRenderer.html = function(html) { return false }
 inlineRenderer.heading = function(text, level, raw) { return '<strong>'+unquote(text)+'</strong> ' }
@@ -106,6 +106,14 @@ inlineRenderer.del = function(text) { return unquote(text) }
 inlineRenderer.mention = function(preceding, id) { return unquote((preceding||'') + id) }
 function unquote (text) {
   return text.replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, '\'')
+}
+function quote (text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/\n+/g, ' ')
 }
 
 marked.setOptions({

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "ssb-msgs": "^5.2.0",
     "ssb-ref": "^2.2.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "tape": "^4.4.0"
+  },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"
   },

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "ssb-markdown",
   "description": "patchwork's markdown parser",
   "version": "1.0.0",
-  "homepage": "https://github.com/dominictarr/ssb-markdown",
+  "homepage": "https://github.com/ssbc/ssb-markdown",
   "repository": {
     "type": "git",
-    "url": "git://github.com/dominictarr/ssb-markdown.git"
+    "url": "git://github.com/ssbc/ssb-markdown.git"
   },
   "dependencies": {
     "emoji-named-characters": "^1.0.2",

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,20 @@ var input = [
     "channel": "patchwork-dev"
   },
   "signature": "3NSPu1MDxKTil1WqWWNcoD3f2IZlLpzy0kJY1UDf9EsOZ8IEsm1kC9kVzZCP3bxm1wmU66e0DSIneuGnlFNwAg==.sig.ed25519"
+},
+
+{
+  "previous": "%2Clc1DI+eGfyROos8lURqXmYiCGf9p1F+Xx2w+xFmfI=.sha256",
+  "author": "@vt8uK0++cpFioCCBeB3p3jdx4RIdQYJOL/imN1Hv0Wk=.ed25519",
+  "sequence": 238,
+  "timestamp": 1451738152178,
+  "hash": "sha256",
+  "content": {
+    "type": "post",
+    "text": "UI experiment: JSX-inspired es6 tagged template string function: [hyperx](https://github.com/substack/hyperx). Inline HTML templates for multiple engines (hyperscript, virtual-dom, react) without a transpiler.\n\nHere's the virtual-dom/main-loop example:\n\n``` js\nvar vdom = require('virtual-dom')\nvar hyperx = require('hyperx')\nvar hx = hyperx(vdom.h)\n\nvar main = require('main-loop')\nvar loop = main({ times: 0 }, render, vdom)\ndocument.querySelector('#content').appendChild(loop.target)\n\nfunction render (state) {\n  return hx`<div>\n    <h1>clicked ${state.times} times</h1>\n    <button onclick=${onclick}>click me!</button>\n  </div>`\n\n  function onclick () {\n    loop.update({ times: state.times + 1 })\n  }\n}\n```",
+    "channel": "modules"
+  },
+  "signature": "GgS7QYd8iG1sXIGqyODUqvL6WenVrY8C5GUBf/xzVXrmZJBfHGfBglopJslFVsY7mQ4EA8Y4qh0haGS3xMjSCA==.sig.ed25519"
 }
 
 ]
@@ -81,14 +95,16 @@ var output = [
 '<p>i was hoping this would be <a href="https://github.com/breach" target="_blank">ultrabrowser</a> but it hasn&#39;t turned out that great.  But image a good base would look something like <a href="http://surf.suckless.org/" target="_blank">Surf</a></p>',
 '<p>At Pidgon River nature preserve in Indiana<br><a href="#/webview/%26RRELXJAxum631eq1ikj7%2Bqngd3f6Dvz7eA1mZNHBPQ0%3D.sha256"><img src="http://localhost:7777/&RRELXJAxum631eq1ikj7+qngd3f6Dvz7eA1mZNHBPQ0=.sha256?fallback=img" alt="IMG_20160107_170558 (1).jpg"></a></p>',
 '<p><a href="#/profile/%40hxGxqPrplLjRG2vtjQL87abX4QKqeLgCwQpS730nNwE%3D.ed25519">@paul</a> <a href="#/profile/%40ye%2BQM09iPcDJD6YvQYjoQc7sLF%2FIFhmNbEqgdzQo3lQ%3D.ed25519">@mixmix</a> in the latest version there isn&#39;t anyway to see who is on a thread until you see them reply. In previous versions the other recipients where in the reply form, but that is gone now. I can imagine some unfortunate things being said because someone doesn&#39;t realize who else is on that thread.</p>',
-'<p>If somebody&#39;s looking for a UI task to hack on, the <a href="https://github.com/ssbc/patchwork/issues/218" target="_blank">Expand threads in-place</a> is a moderate-sized item that I&#39;d love to get in. I&#39;m going to work on the social and onboarding bits now, so I won&#39;t be able to get to it for a bit.</p>\n<p>There will be <img src="./img/emoji/cake.png" alt=":cake:" title=":cake:" class="emoji" align="absmiddle" height="16" width="16"> and <img src="./img/emoji/cookie.png" alt=":cookie:" title=":cookie:" class="emoji" align="absmiddle" height="16" width="16">s and <img src="./img/emoji/heart.png" alt=":heart:" title=":heart:" class="emoji" align="absmiddle" height="16" width="16">s as a reward</p>'
+'<p>If somebody&#39;s looking for a UI task to hack on, the <a href="https://github.com/ssbc/patchwork/issues/218" target="_blank">Expand threads in-place</a> is a moderate-sized item that I&#39;d love to get in. I&#39;m going to work on the social and onboarding bits now, so I won&#39;t be able to get to it for a bit.</p>\n<p>There will be <img src="./img/emoji/cake.png" alt=":cake:" title=":cake:" class="emoji" align="absmiddle" height="16" width="16"> and <img src="./img/emoji/cookie.png" alt=":cookie:" title=":cookie:" class="emoji" align="absmiddle" height="16" width="16">s and <img src="./img/emoji/heart.png" alt=":heart:" title=":heart:" class="emoji" align="absmiddle" height="16" width="16">s as a reward</p>',
+'<p>UI experiment: JSX-inspired es6 tagged template string function: <a href="https://github.com/substack/hyperx" target="_blank">hyperx</a>. Inline HTML templates for multiple engines (hyperscript, virtual-dom, react) without a transpiler.</p>\n<p>Here&#39;s the virtual-dom/main-loop example:</p>\n<pre><code class="lang-js">var vdom = require(&#39;virtual-dom&#39;)\nvar hyperx = require(&#39;hyperx&#39;)\nvar hx = hyperx(vdom.h)\n\nvar main = require(&#39;main-loop&#39;)\nvar loop = main({ times: 0 }, render, vdom)\ndocument.querySelector(&#39;#content&#39;).appendChild(loop.target)\n\nfunction render (state) {\n  return hx`&lt;div&gt;\n    &lt;h1&gt;clicked ${state.times} times&lt;/h1&gt;\n    &lt;button onclick=${onclick}&gt;click me!&lt;/button&gt;\n  &lt;/div&gt;`\n\n  function onclick () {\n    loop.update({ times: state.times + 1 })\n  }\n}\n</code></pre>'
 ]
 
 var outputInline = [
 "i was hoping this would be ultrabrowser but it hasn't turned out that great.  But image a good base would look something like Surf ",
 "At Pidgon River nature preserve in Indiana IMG_20160107_170558 (1).jpg ",
 "@paul @mixmix in the latest version there isn't anyway to see who is on a thread until you see them reply. In previous versions the other recipients where in the reply form, but that is gone now. I can imagine some unfortunate things being said because someone doesn't realize who else is on that thread. ",
-"If somebody's looking for a UI task to hack on, the Expand threads in-place is a moderate-sized item that I'd love to get in. I'm going to work on the social and onboarding bits now, so I won't be able to get to it for a bit. There will be <img src=\"./img/emoji/cake.png\" alt=\":cake:\" title=\":cake:\" class=\"emoji\" align=\"absmiddle\" height=\"12\" width=\"12\"> and <img src=\"./img/emoji/cookie.png\" alt=\":cookie:\" title=\":cookie:\" class=\"emoji\" align=\"absmiddle\" height=\"12\" width=\"12\">s and <img src=\"./img/emoji/heart.png\" alt=\":heart:\" title=\":heart:\" class=\"emoji\" align=\"absmiddle\" height=\"12\" width=\"12\">s as a reward "
+"If somebody's looking for a UI task to hack on, the Expand threads in-place is a moderate-sized item that I'd love to get in. I'm going to work on the social and onboarding bits now, so I won't be able to get to it for a bit. There will be <img src=\"./img/emoji/cake.png\" alt=\":cake:\" title=\":cake:\" class=\"emoji\" align=\"absmiddle\" height=\"12\" width=\"12\"> and <img src=\"./img/emoji/cookie.png\" alt=\":cookie:\" title=\":cookie:\" class=\"emoji\" align=\"absmiddle\" height=\"12\" width=\"12\">s and <img src=\"./img/emoji/heart.png\" alt=\":heart:\" title=\":heart:\" class=\"emoji\" align=\"absmiddle\" height=\"12\" width=\"12\">s as a reward ",
+"UI experiment: JSX-inspired es6 tagged template string function: hyperx. Inline HTML templates for multiple engines (hyperscript, virtual-dom, react) without a transpiler. Here's the virtual-dom/main-loop example: var vdom = require('virtual-dom') var hyperx = require('hyperx') var hx = hyperx(vdom.h) var main = require('main-loop') var loop = main({ times: 0 }, render, vdom) document.querySelector('#content').appendChild(loop.target) function render (state) {   return hx`&lt;div&gt;     &lt;h1&gt;clicked ${state.times} times&lt;/h1&gt;     &lt;button onclick=${onclick}&gt;click me!&lt;/button&gt;   &lt;/div&gt;`   function onclick () {     loop.update({ times: state.times + 1 })   } } "
 ]
 
 
@@ -98,7 +114,8 @@ var tests = [
   'message with link',
   'message with image',
   'message with "@" mentions',
-  'message with emoji'
+  'message with emoji',
+  'message with inline html in code block'
 ]
 
 var tape = require('tape')

--- a/test/index.js
+++ b/test/index.js
@@ -125,18 +125,18 @@ var tape = require('tape')
 tests.forEach(function (e, i) {
   tape(e, function (t) {
     t.equal(
-      output[i].trim(),
       markdown.block(
         input[i].content.text,
         input[i].content.mentions
-      ).trim()
+      ).trim(),
+      output[i].trim()
     )
     t.end()
   })
   tape(e, function (t) {
     t.equal(
-      outputInline[i].trim(),
-      markdown.inline(input[i].content.text).trim()
+      markdown.inline(input[i].content.text).trim(),
+      outputInline[i].trim()
     )
     t.end()
   })


### PR DESCRIPTION
In the Patchwork newsfeed, in Large or Compact view (which use `markdown.inline`), some HTML can be seen to leak from the markdown. For example, find <http://localhost:7777/#/msg/%25NpEZzVHrfVlS8QW%2BtyJPUGmWbWh3x2O6MIgdxQK%2F0xI%3D.sha256> in the #modules channel <http://localhost:7777/#/newsfeed/channel/modules>.

![2016-01-19-200335_1280x800_scrot](https://cloud.githubusercontent.com/assets/95347/12436968/c576ced0-bee7-11e5-8e2f-43dcc18af246.png)
