### PR TITLE
No longer will rewrite URLs that include ssb-refs in them

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,18 +24,8 @@ blockRenderer.urltransform = function (url) {
     }
   }
 
-  // is this an ssb ref, or perhaps a ref within an HTTP url?
-  var isSsbRef = ssbref.isLink(url)
-  if (!isSsbRef) {
-    // check if there's a ref inside somewhere
-    var ref = ssbref.extract(url)
-    if (ref) {
-      url = ref
-      isSsbRef = true
-    }
-  }
-
   // use our own link if this is an ssb ref
+  var isSsbRef = ssbref.isLink(url)
   if ((hasSigil || isSsbRef) && this.options.toUrl) {
     return this.options.toUrl(url)
   }


### PR DESCRIPTION
SSB-Markdown currently will detect HTTP urls with ssb refs in them, extract the ref, and then rewrite the link using `toUrl()`. The idea was that you should open the target ref in the current application, but that ended up being a silly idea that surprised people. So, this PR removes it.