### PR TITLE
Differentiate image URLs from link URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var md = require('ssb-markdown')
 Render raw markdown `source` to html.
 The output will be html content without a surrounding tag.
 
-`toUrl` is a function which accepts an [ssb-ref](https://github.com/ssbc/ssb-links) or @-mention string,
+`toUrl` is a function which accepts an [ssb-ref](https://github.com/ssbc/ssb-links) or @-mention string, and whether it is for an image or not,
 and returns a url string.
 
 ### md.inline (source)

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ blockRenderer.urltransform = function (url) {
   // use our own link if this is an ssb ref
   var isSsbRef = ssbref.isLink(url)
   if ((hasSigil || isSsbRef) && this.options.toUrl) {
-    return this.options.toUrl(url)
+    return this.options.toUrl(url, false)
   }
   return url
 }
@@ -57,7 +57,7 @@ blockRenderer.link = function(href, title, text) {
 blockRenderer.image  = function (href, title, text) {
   href = href.replace(/^&amp;/, '&')
   if (ssbref.isLink(href) && this.options.toUrl) {
-    var url = this.options.toUrl(href)
+    var url = this.options.toUrl(href, true)
     var out = '<img src="'+url+'" alt="' + text + '"'
     if (title) {
       out += ' title="' + title + '"'

--- a/test/index.js
+++ b/test/index.js
@@ -135,7 +135,7 @@ tests.forEach(function (e, i) {
         mentionNames[name] = link.link
       }
     })
-    var toUrl = function (ref) {
+    var toUrl = function (ref, isImage) {
       // @-mentions
       if (ref in mentionNames)
         return '#/profile/'+encodeURIComponent(mentionNames[ref])


### PR DESCRIPTION
This adds an isImage paramter to toUrl. Is it a bit of a hack but the simplest change I could find to make work what I want to work, which is to have URLs for blobs being used as images to be handled differently from URLs for blobs being used as links. This is for the ssb-frame feature in development for patchbay: %t+lv57wu9MoeTOQFfEX+nilUJHSoUaYbt9iovbpXiLk=.sha256