### PR TITLE
add option to link images & add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -58,12 +58,14 @@ blockRenderer.image  = function (href, title, text) {
   href = href.replace(/^&amp;/, '&')
   if (ssbref.isLink(href) && this.options.toUrl) {
     var url = this.options.toUrl(href, true)
-    var out = '<img src="'+url+'" alt="' + text + '"'
-    if (title) {
-      out += ' title="' + title + '"'
-    }
-    out += '>'
-    return out
+    var hrefAttr = this.options.imageLink
+      ? ' href="' + this.options.imageLink(href) + '"'
+      : ''
+    var titleAttr = title
+      ? ' title="' + title + '"'
+      : ''
+
+    return '<a' + hrefAttr + '><img src="'+url+'" alt="' + text + '"' + titleAttr + '></a>'
   }
   return text
 }

--- a/test/index.js
+++ b/test/index.js
@@ -93,7 +93,7 @@ var input = [
 
 var output = [
 '<p>i was hoping this would be <a href="https://github.com/breach" target="_blank">ultrabrowser</a> but it hasn&#39;t turned out that great.  But image a good base would look something like <a href="http://surf.suckless.org/" target="_blank">Surf</a></p>',
-'<p>At Pidgon River nature preserve in Indiana<br><img src="/%26RRELXJAxum631eq1ikj7%2Bqngd3f6Dvz7eA1mZNHBPQ0%3D.sha256" alt="IMG_20160107_170558 (1).jpg"></p>',
+'<p>At Pidgon River nature preserve in Indiana<br><a href="#&RRELXJAxum631eq1ikj7+qngd3f6Dvz7eA1mZNHBPQ0=.sha256"><img src="/%26RRELXJAxum631eq1ikj7%2Bqngd3f6Dvz7eA1mZNHBPQ0%3D.sha256" alt="IMG_20160107_170558 (1).jpg"></a></p>',
 '<p><a href="#/profile/%40hxGxqPrplLjRG2vtjQL87abX4QKqeLgCwQpS730nNwE%3D.ed25519">@paul</a> <a href="#/profile/%40ye%2BQM09iPcDJD6YvQYjoQc7sLF%2FIFhmNbEqgdzQo3lQ%3D.ed25519">@mixmix</a> in the latest version there isn&#39;t anyway to see who is on a thread until you see them reply. In previous versions the other recipients where in the reply form, but that is gone now. I can imagine some unfortunate things being said because someone doesn&#39;t realize who else is on that thread.</p>',
 '<p>If somebody&#39;s looking for a UI task to hack on, the <a href="https://github.com/ssbc/patchwork/issues/218" target="_blank">Expand threads in-place</a> is a moderate-sized item that I&#39;d love to get in. I&#39;m going to work on the social and onboarding bits now, so I won&#39;t be able to get to it for a bit.</p>\n<p>There will be <img src="./img/emoji/cake.png" alt=":cake:" title=":cake:" class="emoji" align="absmiddle" height="16" width="16"> and <img src="./img/emoji/cookie.png" alt=":cookie:" title=":cookie:" class="emoji" align="absmiddle" height="16" width="16">s and <img src="./img/emoji/heart.png" alt=":heart:" title=":heart:" class="emoji" align="absmiddle" height="16" width="16">s as a reward</p>',
 '<p>UI experiment: JSX-inspired es6 tagged template string function: <a href="https://github.com/substack/hyperx" target="_blank">hyperx</a>. Inline HTML templates for multiple engines (hyperscript, virtual-dom, react) without a transpiler.</p>\n<p>Here&#39;s the virtual-dom/main-loop example:</p>\n<pre><code class="lang-js">var vdom = require(&#39;virtual-dom&#39;)\nvar hyperx = require(&#39;hyperx&#39;)\nvar hx = hyperx(vdom.h)\n\nvar main = require(&#39;main-loop&#39;)\nvar loop = main({ times: 0 }, render, vdom)\ndocument.querySelector(&#39;#content&#39;).appendChild(loop.target)\n\nfunction render (state) {\n  return hx`&lt;div&gt;\n    &lt;h1&gt;clicked ${state.times} times&lt;/h1&gt;\n    &lt;button onclick=${onclick}&gt;click me!&lt;/button&gt;\n  &lt;/div&gt;`\n\n  function onclick () {\n    loop.update({ times: state.times + 1 })\n  }\n}\n</code></pre>'
@@ -150,10 +150,17 @@ tests.forEach(function (e, i) {
       return ''
     }
 
+    var imageLink = function (ref) {
+      return '#' + ref
+    }
+
     t.equal(
       markdown.block(
         input[i].content.text,
-        { toUrl: toUrl }
+        { 
+          toUrl: toUrl,
+          imageLink: imageLink
+        }
       ).trim(),
       output[i].trim()
     )


### PR DESCRIPTION
This adds the option to have image tags have a custom href.

This is so Patchbay images can open easily in new tabs. 
Smoke tested over there and works fine.