### PR TITLE
call toUrl on anything that might be a URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ blockRenderer.link = function(href, title, text) {
 
 blockRenderer.image  = function (href, title, text) {
   href = href.replace(/^&amp;/, '&')
-  if (ssbref.isLink(href) && this.options.toUrl) {
+  if (this.options.toUrl) {
     var url = this.options.toUrl(href, true)
     var out = '<img src="'+url+'" alt="' + text + '"'
     if (title) {


### PR DESCRIPTION
instead of restricting to just a URL, allow the toUrl option to handle any interesting cases.
the motivating case for this is private blobs... this feature depends on a couple other PRs those will be linked here too.