### PR TITLE
allow embedded audio and video

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,9 @@ blockRenderer.image  = function (href, title, text) {
       ? ' title="' + title + '"'
       : ''
 
-    if (url.includes('contentType=video')) {
+    if (text.startsWith('video:')) {
       return '<video controls src="'+url+'" alt="' + text + '"' + titleAttr + ' />'
-    } else if (url.includes('contentType=audio')) {
+    } else if (text.startsWith('audio:')) {
       return '<audio controls src="'+url+'" alt="' + text + '"' + titleAttr + ' />'
     } else {
       var hrefAttr = this.options.imageLink

--- a/index.js
+++ b/index.js
@@ -62,9 +62,9 @@ blockRenderer.image  = function (href, title, text) {
       ? ' title="' + title + '"'
       : ''
 
-    if (url.includes('contentType=video/')) {
+    if (url.includes('contentType=video')) {
       return '<video controls src="'+url+'" alt="' + text + '"' + titleAttr + ' />'
-    } else if (url.includes('contentType=audio/')) {
+    } else if (url.includes('contentType=audio')) {
       return '<audio controls src="'+url+'" alt="' + text + '"' + titleAttr + ' />'
     } else {
       var hrefAttr = this.options.imageLink

--- a/index.js
+++ b/index.js
@@ -58,14 +58,21 @@ blockRenderer.image  = function (href, title, text) {
   href = href.replace(/^&amp;/, '&')
   if (this.options.toUrl) {
     var url = this.options.toUrl(href, true)
-    var hrefAttr = this.options.imageLink
-      ? ' href="' + this.options.imageLink(href) + '"'
-      : ''
     var titleAttr = title
       ? ' title="' + title + '"'
       : ''
 
-    return '<a' + hrefAttr + '><img src="'+url+'" alt="' + text + '"' + titleAttr + '></a>'
+    if (url.includes('contentType=video/')) {
+      return '<video controls src="'+url+'" alt="' + text + '"' + titleAttr + ' />'
+    } else if (url.includes('contentType=audio/')) {
+      return '<audio controls src="'+url+'" alt="' + text + '"' + titleAttr + ' />'
+    } else {
+      var hrefAttr = this.options.imageLink
+        ? ' href="' + this.options.imageLink(href) + '"'
+        : ''
+
+      return '<a' + hrefAttr + '><img src="'+url+'" alt="' + text + '"' + titleAttr + '></a>'
+    }
   }
   return text
 }


### PR DESCRIPTION
It has been suggested many times that ssb markdown should allow embedded audio and video.

This PR adds this by reusing the standard `![image](embed)` but checking to see if the resolved URL contains `contentType=video/` or `contentType=audio/` in the query string. If it does, instead of inserting an `<img>` tag, it does an `<audio>` or `<video>` respectively. 

I've modified patchcore to append the `contentType` to the url (from the mentions) when rendering markdown:

https://github.com/ssbc/patchcore/blob/a61f3a4f15d549be32ee33146be221e1f525cea3/message/html/markdown.js#L50-L57

Which clients are using ssb-markdown? Can the authors please chime in with opinions on this approach?

cc @clehner @dominictarr @mixmix 