### PR TITLE
Documentation Drive Week 6: Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,34 @@ standard markdown.
 var md = require('ssb-markdown')
 ```
 
-### md.block(source, { toUrl:, imageLink: })
+### md.block(source, opts)
 
 Render raw markdown `source` to html.
 The output will be html content without a surrounding tag.
+
+### md.inline (source, opts)
+
+Render raw markdown to a single line of test,
+suitable for a one line preview that is opened
+to a view rendered with `block`.
+
+### opts
+
+An object containing custom markdown parsing function. `opts` are the
+same for both `md.block` and `md.inline`
+
+#### usage
+
+```js
+const opts = {
+  toUrl: ref => ref,
+  toImage: ref => ref,
+  emoji: emojiAsMarkup => doSomeParsing(emojiAsMarkup)
+}
+md.block(source, opts)
+
+md.inline(source, opts)
+```
 
 `toUrl` is a function which accepts an [ssb-ref](https://github.com/ssbc/ssb-links) or @-mention string, and whether it is for an image or not,
 and returns a url string.
@@ -26,12 +50,8 @@ and returns a url string.
 
 `imageLink` is a function which accepts an [ssb-ref](https://github.com/ssbc/ssb-links) and will be used to generate links to wrap any images.
 
-
-### md.inline (source)
-
-Render raw markdown to a single line of test,
-suitable for a one line preview that is opened
-to a view rendered with `block`.
+`emoji` is a function which accepts an emoji as markup and
+over-rides the default emoji rendering behavior.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ to a view rendered with `block`.
 An object containing custom markdown parsing function. `opts` are the
 same for both `md.block` and `md.inline`
 
+`toUrl` is a function which accepts an [ssb-ref](https://github.com/ssbc/ssb-links) or @-mention string, and whether it is for an image or not,
+and returns a url string.
+
+
+`imageLink` is a function which accepts an [ssb-ref](https://github.com/ssbc/ssb-links) and will be used to generate links to wrap any images.
+
+`emoji` is a function which accepts an emoji as markup and
+over-rides the default emoji rendering behavior.
+
+
 #### usage
 
 ```js
@@ -43,15 +53,6 @@ md.block(source, opts)
 
 md.inline(source, opts)
 ```
-
-`toUrl` is a function which accepts an [ssb-ref](https://github.com/ssbc/ssb-links) or @-mention string, and whether it is for an image or not,
-and returns a url string.
-
-
-`imageLink` is a function which accepts an [ssb-ref](https://github.com/ssbc/ssb-links) and will be used to generate links to wrap any images.
-
-`emoji` is a function which accepts an emoji as markup and
-over-rides the default emoji rendering behavior.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ to a view rendered with `block`.
 
 ### opts
 
-An object containing custom markdown parsing function. `opts` are the
+An object containing custom markdown rendering functions. `opts` are the
 same for both `md.block` and `md.inline`
 
 `toUrl` is a function which accepts an [ssb-ref](https://github.com/ssbc/ssb-links) or @-mention string, and whether it is for an image or not,
@@ -45,10 +45,11 @@ over-rides the default emoji rendering behavior.
 
 ```js
 const opts = {
-  toUrl: ref => ref,
-  toImage: ref => ref,
-  emoji: emojiAsMarkup => doSomeParsing(emojiAsMarkup)
+  toUrl: ref => renderUrlRef(ref),
+  toImage: ref => renderImageRef(ref),
+  emoji: emojiAsMarkup => renderEmoji(emojiAsMarkup)
 }
+
 md.block(source, opts)
 
 md.inline(source, opts)


### PR DESCRIPTION
Added more details around acceptable options for both `inline` and `block` method