### PR TITLE
Fix external images being rendered by default

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -4,6 +4,7 @@ const hljs = require('highlight.js')
 const util = require('./util')
 const emojiByShortcode = require('markdown-it-emoji/lib/data/full.json')
 const hashtagRegex = require('hashtag-regex')
+const ssbRef = require('ssb-ref')
 
 // The hashtag-regex module comes with a regex that auto-detects the number sign
 // characters, but markdown-it-hashtag wants to handle that by itself. This
@@ -170,7 +171,9 @@ md.linkify.add('@', {
 md.renderer.rules.image = (tokens, idx, options, env, self) => {
   const token = tokens[idx]
 
-  const srcText = token.attrGet('src')
+  const rawSrc = token.attrGet('src')
+  const srcText = ssbRef.isBlob(rawSrc) ? rawSrc : ''
+
   const title = token.attrGet('title')
   const alt = token.content
   const src = config.toUrl(srcText, true)
@@ -184,7 +187,7 @@ md.renderer.rules.image = (tokens, idx, options, env, self) => {
   Object
     .entries(media)
     .forEach(([key, value]) => {
-      if (value && value.length) {
+      if (value != null) {
         tokens[idx].attrSet(key, value)
       }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,9 +210,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "concat-map": {
@@ -1138,9 +1138,9 @@
       }
     },
     "moo": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
       "dev": true
     },
     "ms": {
@@ -1171,13 +1171,13 @@
       "dev": true
     },
     "nearley": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.1.tgz",
+      "integrity": "sha512-xq47GIUGXxU9vQg7g/y1o1xuKnkO7ev4nRWqftmQrLkfnE/FjRqDaGOUakM8XHPn/6pW3bGjU2wgoJyId90rqg==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
-        "moo": "^0.4.3",
+        "moo": "^0.5.0",
         "railroad-diagrams": "^1.0.0",
         "randexp": "0.4.6",
         "semver": "^5.4.1"

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,8 @@ var tests = [
   'message with compound emoji',
   'message with node-emoji shortcodes',
   'message with sigil links in proper Markdown',
-  'message with non-ASCII unicode hashtag'
+  'message with non-ASCII unicode hashtag',
+  'message with external image'
 ]
 
 // behavior expected by current tests

--- a/test/input.json
+++ b/test/input.json
@@ -191,5 +191,10 @@
     "content": {
       "text": "#轻拿轻放 #a-b+c.d #🙃"
     }
+  },
+  {
+    "content": {
+      "text": "![](https://ia601400.us.archive.org/27/items/ssb_20200107/ssb.png)"
+    }
   }
 ]

--- a/test/output-inline.json
+++ b/test/output-inline.json
@@ -12,5 +12,6 @@
   "<span class=\"emoji\">👨🏾‍🎤</span>",
   "<span class=\"emoji\">🤖</span> = <span class=\"emoji\">🤖</span>",
   "this link should pass through toUrl",
-  "#轻拿轻放 #a-b+c.d #<span class=\"emoji\">🙃</span>"
+  "#轻拿轻放 #a-b+c.d #<span class=\"emoji\">🙃</span>",
+  ""
 ]

--- a/test/output.json
+++ b/test/output.json
@@ -12,6 +12,7 @@
   "<p><span class=\"emoji\">👨🏾‍🎤</span></p>\n",
   "<p><span class=\"emoji\">🤖</span> = <span class=\"emoji\">🤖</span></p>\n",
   "<p><a href=\"#/profile/%40%2BUMKhpbzXAII%2B2%2F7ZlsgkJwIsxdfeFi36Z5Rk1gCfY0%3D.ed25519\">this link should pass through toUrl</a></p>\n",
-  "<p><a href=\"#/channel/轻拿轻放\">#轻拿轻放</a> <a href=\"#/channel/a-b+c\">#a-b+c</a>.d <a href=\"#/channel/%F0%9F%99%83\">#<span class=\"emoji\">🙃</span></a></p>\n"
+  "<p><a href=\"#/channel/轻拿轻放\">#轻拿轻放</a> <a href=\"#/channel/a-b+c\">#a-b+c</a>.d <a href=\"#/channel/%F0%9F%99%83\">#<span class=\"emoji\">🙃</span></a></p>\n",
+  "<p><img src=\"\" alt=\"\"></p>\n"
 ]
 


### PR DESCRIPTION
Problem: We don't want external HTTP requests to be made so it's bad if
people can embed images with remote URLS. This library was allowing that
behavior to happen by default, although clients could fix this with the
`imageLink()` method. See also: #51.

Solution: Always check Markdown images (which includes audio and video
(!)) and strip all values that aren't valid blob references according to
SSB-Ref.