### PR TITLE
Fix private blob urls

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -172,7 +172,9 @@ md.renderer.rules.image = (tokens, idx, options, env, self) => {
   const token = tokens[idx]
 
   const rawSrc = token.attrGet('src')
-  const srcText = ssbRef.isBlob(rawSrc) ? rawSrc : ''
+
+  const link = ssbRef.parseLink(rawSrc)
+  const srcText = ssbRef.isBlob(link ? link.link : '') ? rawSrc : ''
 
   const title = token.attrGet('title')
   const alt = token.content

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,8 @@ var tests = [
   'message with node-emoji shortcodes',
   'message with sigil links in proper Markdown',
   'message with non-ASCII unicode hashtag',
-  'message with external image'
+  'message with external image',
+  'message with private image'
 ]
 
 // behavior expected by current tests
@@ -45,12 +46,14 @@ tests.forEach(function (e, i) {
         return '#/profile/' + encodeURIComponent(mentionNames[ref])
       }
 
+      const link = ssbref.parseLink(ref)
+
       // standard ssb-refs
       if (ssbref.isFeedId(ref)) {
         return '#/profile/' + encodeURIComponent(ref)
       } else if (ssbref.isMsgId(ref)) {
         return '#/msg/' + encodeURIComponent(ref)
-      } else if (ssbref.isBlobId(ref)) {
+      } else if (ssbref.isBlobId(link ? link.link : ref)) {
         return '/' + encodeURIComponent(ref)
       } else if (ref && ref[0] === '#') {
         return '#/channel/' + ref.substr(1)

--- a/test/input.json
+++ b/test/input.json
@@ -196,5 +196,10 @@
     "content": {
       "text": "![](https://ia601400.us.archive.org/27/items/ssb_20200107/ssb.png)"
     }
+  },
+  {
+    "content": {
+      "text": "![horizon.jpg](&RKIo6y4ARizHDPKOo00aiFCRyUtO9lBcr8O2fOmOk6I=.sha256?unbox=LOLyeahrightNotGoingToHappen=.boxs)"
+    }
   }
 ]

--- a/test/output-inline.json
+++ b/test/output-inline.json
@@ -13,5 +13,6 @@
   "<span class=\"emoji\">🤖</span> = <span class=\"emoji\">🤖</span>",
   "this link should pass through toUrl",
   "#轻拿轻放 #a-b+c.d #<span class=\"emoji\">🙃</span>",
-  ""
+  "",
+  "horizon.jpg"
 ]

--- a/test/output.json
+++ b/test/output.json
@@ -13,6 +13,7 @@
   "<p><span class=\"emoji\">🤖</span> = <span class=\"emoji\">🤖</span></p>\n",
   "<p><a href=\"#/profile/%40%2BUMKhpbzXAII%2B2%2F7ZlsgkJwIsxdfeFi36Z5Rk1gCfY0%3D.ed25519\">this link should pass through toUrl</a></p>\n",
   "<p><a href=\"#/channel/轻拿轻放\">#轻拿轻放</a> <a href=\"#/channel/a-b+c\">#a-b+c</a>.d <a href=\"#/channel/%F0%9F%99%83\">#<span class=\"emoji\">🙃</span></a></p>\n",
-  "<p><img src=\"\" alt=\"\"></p>\n"
+  "<p><img src=\"\" alt=\"\"></p>\n",
+  "<p><img src=\"/%26RKIo6y4ARizHDPKOo00aiFCRyUtO9lBcr8O2fOmOk6I%3D.sha256%3Funbox%3DLOLyeahrightNotGoingToHappen%3D.boxs\" alt=\"horizon.jpg\"></p>\n"
 ]
 


### PR DESCRIPTION
This fixes #53. The ssb-ref implementation of blobs is a little [funky](https://github.com/ssbc/ssb-ref/blob/master/test/index.js#L209). So we need this dance for private blobs to work.