### PR TITLE
Fix URI encoding bug

### DIFF
--- a/lib/block.js
+++ b/lib/block.js
@@ -100,8 +100,7 @@ md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
     }
   }
 
-  const oldLinkOpenRenderResult = oldLinkOpenRender(tokens, idx, options, env, self)
-  return oldLinkOpenRenderResult// .replace('<a href="%25', '<a href="%')
+  return oldLinkOpenRender(tokens, idx, options, env, self)
 }
 
 const sigilRegExp = new RegExp(/^[a-zA-Z0-9+/=]{44}\.[a-z0-9]+/)
@@ -127,7 +126,7 @@ sigils.forEach(sigil => {
     },
     normalize: function (match) {
       match.text = util.formatSigilText(match.text)
-      match.url = match.raw
+      match.url = encodeURI(match.raw)
       return match
     }
   })

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,8 @@ var tests = [
   'message with sigil links in proper Markdown',
   'message with non-ASCII unicode hashtag',
   'message with external image',
-  'message with private image'
+  'message with private image',
+  'message with %70 link'
 ]
 
 // behavior expected by current tests

--- a/test/input.json
+++ b/test/input.json
@@ -201,5 +201,10 @@
     "content": {
       "text": "![horizon.jpg](&RKIo6y4ARizHDPKOo00aiFCRyUtO9lBcr8O2fOmOk6I=.sha256?unbox=LOLyeahrightNotGoingToHappen=.boxs)"
     }
+  },
+  {
+    "content": {
+      "text": "Look at this thread: %70B9TI2hP5QMU59Lx9ozRD5Uh/E7tq4o1Ox8TP07XIg=.sha256"
+    }
   }
 ]

--- a/test/output-inline.json
+++ b/test/output-inline.json
@@ -14,5 +14,6 @@
   "this link should pass through toUrl",
   "#轻拿轻放 #a-b+c.d #<span class=\"emoji\">🙃</span>",
   "",
-  "horizon.jpg"
+  "horizon.jpg",
+  "Look at this thread: %70B9TI2hP5QMU59Lx9ozRD5Uh/E7tq4o1Ox8TP07XIg=.sha256"
 ]

--- a/test/output.json
+++ b/test/output.json
@@ -14,6 +14,7 @@
   "<p><a href=\"#/profile/%40%2BUMKhpbzXAII%2B2%2F7ZlsgkJwIsxdfeFi36Z5Rk1gCfY0%3D.ed25519\">this link should pass through toUrl</a></p>\n",
   "<p><a href=\"#/channel/轻拿轻放\">#轻拿轻放</a> <a href=\"#/channel/a-b+c\">#a-b+c</a>.d <a href=\"#/channel/%F0%9F%99%83\">#<span class=\"emoji\">🙃</span></a></p>\n",
   "<p><img src=\"\" alt=\"\"></p>\n",
-  "<p><img src=\"/%26RKIo6y4ARizHDPKOo00aiFCRyUtO9lBcr8O2fOmOk6I%3D.sha256%3Funbox%3DLOLyeahrightNotGoingToHappen%3D.boxs\" alt=\"horizon.jpg\"></p>\n"
+  "<p><img src=\"/%26RKIo6y4ARizHDPKOo00aiFCRyUtO9lBcr8O2fOmOk6I%3D.sha256%3Funbox%3DLOLyeahrightNotGoingToHappen%3D.boxs\" alt=\"horizon.jpg\"></p>\n",
+  "<p>Look at this thread: <a href=\"#/msg/%2570B9TI2hP5QMU59Lx9ozRD5Uh%2FE7tq4o1Ox8TP07XIg%3D.sha256\">%70B9T...</a></p>\n"
 ]
 


### PR DESCRIPTION
Problem: Some sigil links are broken because of some URI handling,
which looks like it's caused by a lack of `encodeURI()` before passing
on the sigil link href.

Solution: Add the magical `encodeURI()` and tests to ensure it works
correctly.