### PR TITLE
Steal GH Actions for PR tests from Oasis

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,28 @@
+name: Node.js CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: node_js
-node_js: lts/*

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "tape": "^4.13.2"
   },
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "tape ./test"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "maintainers": [


### PR DESCRIPTION
> travis ci has forsaken me

--- Christian Bundy

The change in the npm test call is to allow testing on operating systems
with really bad shells.

Also added Node 15.x to the test matrix because that's the current version so makes sense to test for that.