### PR TITLE
Split test names into a separate file

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,30 +2,12 @@ var tape = require('tape')
 var ssbref = require('ssb-ref')
 var mlib = require('ssb-msgs')
 
+var tests = require('./test-names')
 var input = require('./input')
 var output = require('./output')
 var outputInline = require('./output-inline')
 var markdown = require('../')
 
-var tests = [
-  'message with link',
-  'message with image',
-  'message with "@" mentions',
-  'message with emoji',
-  'message with ascii emoji',
-  'message with inline html in code block',
-  'message with hashtag',
-  'message with customs protocols',
-  'message with links, mentions, headers, and code',
-  'message with both emoji and :shortcodes:',
-  'message with compound emoji',
-  'message with node-emoji shortcodes',
-  'message with sigil links in proper Markdown',
-  'message with non-ASCII unicode hashtag',
-  'message with external image',
-  'message with private image',
-  'message with %70 link'
-]
 
 // behavior expected by current tests
 var emoji = (emoji) => `<span class="emoji">${emoji}</span>`

--- a/test/test-names.json
+++ b/test/test-names.json
@@ -1,0 +1,19 @@
+[
+  "message with link",
+  "message with image",
+  "message with '@' mentions",
+  "message with emoji",
+  "message with ascii emoji",
+  "message with inline html in code block",
+  "message with hashtag",
+  "message with customs protocols",
+  "message with links, mentions, headers, and code",
+  "message with both emoji and :shortcodes:",
+  "message with compound emoji",
+  "message with node-emoji shortcodes",
+  "message with sigil links in proper Markdown",
+  "message with non-ASCII unicode hashtag",
+  "message with external image",
+  "message with private image",
+  "message with %70 link"
+]


### PR DESCRIPTION
This has two benefits:

1. As we add tests, the test code stays small and manageable.
2. We can load test names, inputs, and outputs separately as json. This is
   useful for writing re-implementations in other languages.