### PR TITLE
Moar tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -2,30 +2,12 @@ var tape = require('tape')
 var ssbref = require('ssb-ref')
 var mlib = require('ssb-msgs')
 
+var tests = require('./test-names')
 var input = require('./input')
 var output = require('./output')
 var outputInline = require('./output-inline')
 var markdown = require('../')
 
-var tests = [
-  'message with link',
-  'message with image',
-  'message with "@" mentions',
-  'message with emoji',
-  'message with ascii emoji',
-  'message with inline html in code block',
-  'message with hashtag',
-  'message with customs protocols',
-  'message with links, mentions, headers, and code',
-  'message with both emoji and :shortcodes:',
-  'message with compound emoji',
-  'message with node-emoji shortcodes',
-  'message with sigil links in proper Markdown',
-  'message with non-ASCII unicode hashtag',
-  'message with external image',
-  'message with private image',
-  'message with %70 link'
-]
 
 // behavior expected by current tests
 var emoji = (emoji) => `<span class="emoji">${emoji}</span>`

--- a/test/input.json
+++ b/test/input.json
@@ -268,5 +268,15 @@
       ]
     },
     "signature": "tPG2bZ7xVzz46SE3RgC8ir6Z2orIF40g0W88qUpvPQmAyOnOff3B0URHjvjUpkyFL2zp5Xdx+fAdbnv+6MLECQ==.sig.ed25519"
+  },
+  {
+    "content": {
+      "text": "Hello... This is a text with three periods... twice."
+    }
+  },
+  {
+    "content": {
+      "text": "Hello.... This is a text with four periods.... twice."
+    }
   }
 ]

--- a/test/input.json
+++ b/test/input.json
@@ -283,5 +283,15 @@
     "content": {
       "text": "Hey @MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519 check out my markdown parsing!"
     }
+  },
+  {
+    "content": {
+      "text": "Hey check out %9eJYIT1HDNhWOeLK0EhhiHJTPwvDGZWGd/E6CBCG5XY=.sha256 to see my mad ssb skillz!"
+    }
+  },
+  {
+    "content": {
+      "text": "Daan has the most amazing avatar go check it out at &yao786uJVt042IiHj74vSZryrrP3U7tu1Lc6B+4CSLY=.sha256 yo."
+    }
   }
 ]

--- a/test/input.json
+++ b/test/input.json
@@ -239,5 +239,34 @@
       ]
     },
     "signature": "uuS90SXOx8/IsdKZrmoXa/dZohufvlq7L6XZ1it5nPkbqiU1wZB34jdKCuTYSY5qV+IU3uXxwR/2c20hY/KhDg==.sig.ed25519"
+  },
+  {
+    "previous": "%bUz0onjfLyMpi6jTGRPiwNlTAV5fJrXixM8nFELxdEI=.sha256",
+    "sequence": 4841,
+    "author": "@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519",
+    "timestamp": 1607110675693,
+    "hash": "sha256",
+    "content": {
+      "type": "post",
+      "text": "![video:snow.mp4](&P5CAmVEEbJxlCRjcYaxzuE5/FOZ/laDS5aOpTOm2MM0=.sha256)\n\n![video:snoooow.mp4](&v7GopcAhKSsjmkA+A/uf1w3sn10CLMR+eLhl6AWxMnM=.sha256)\n\nFirst birthday snow I've had since ~2012 or so. :)",
+      "mentions": [
+        {
+          "link": "&P5CAmVEEbJxlCRjcYaxzuE5/FOZ/laDS5aOpTOm2MM0=.sha256",
+          "name": "video:snow.mp4",
+          "type": "video/mp4",
+          "size": 4274338
+        },
+        {
+          "link": "&v7GopcAhKSsjmkA+A/uf1w3sn10CLMR+eLhl6AWxMnM=.sha256",
+          "name": "video:snoooow.mp4",
+          "type": "video/mp4",
+          "size": 2478775
+        },
+        {
+          "link": "#grenoble"
+        }
+      ]
+    },
+    "signature": "tPG2bZ7xVzz46SE3RgC8ir6Z2orIF40g0W88qUpvPQmAyOnOff3B0URHjvjUpkyFL2zp5Xdx+fAdbnv+6MLECQ==.sig.ed25519"
   }
 ]

--- a/test/input.json
+++ b/test/input.json
@@ -293,5 +293,10 @@
     "content": {
       "text": "Daan has the most amazing avatar go check it out at &yao786uJVt042IiHj74vSZryrrP3U7tu1Lc6B+4CSLY=.sha256 yo."
     }
+  },
+  {
+    "content": {
+      "text": "@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519test"
+    }
   }
 ]

--- a/test/input.json
+++ b/test/input.json
@@ -278,5 +278,10 @@
     "content": {
       "text": "Hello.... This is a text with four periods.... twice."
     }
+  },
+  {
+    "content": {
+      "text": "Hey @MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519 check out my markdown parsing!"
+    }
   }
 ]

--- a/test/input.json
+++ b/test/input.json
@@ -206,5 +206,38 @@
     "content": {
       "text": "Look at this thread: %70B9TI2hP5QMU59Lx9ozRD5Uh/E7tq4o1Ox8TP07XIg=.sha256"
     }
+  },
+  {
+    "previous": "%nihjqd5jQhf2hpr4Bhg+Qgj52UVRdhX4tM1YkOmtv2Y=.sha256",
+    "sequence": 1368,
+    "author": "@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519",
+    "timestamp": 1569958742078,
+    "hash": "sha256",
+    "content": {
+      "type": "post",
+      "root": "%A1TzUsK+kxBaE8GQg4A5m+e99kADEABlXajFr/EnxUs=.sha256",
+      "branch": "%A1TzUsK+kxBaE8GQg4A5m+e99kADEABlXajFr/EnxUs=.sha256",
+      "reply": {
+        "%A1TzUsK+kxBaE8GQg4A5m+e99kADEABlXajFr/EnxUs=.sha256": "@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519"
+      },
+      "channel": null,
+      "recps": null,
+      "text": "Yeah yeah.... hitting publish prematurely....\nAaaaanyhow, since some people are not on dat and because I can, I'm dropping this off here, too. :)\n\n![audio:threshold_rc2.mp3](&0vj4Oc8AnHAgOpFkikoB3czsCF70pbxDrm/WbbN0kbE=.sha256)\n\n![A line drawing of the scott pilgrim movie poster](&gd+rghJZTGl5m5kuKtSXM9v/ndHP7RqXvXuRciLPkdg=.sha256)\n",
+      "mentions": [
+        {
+          "link": "&0vj4Oc8AnHAgOpFkikoB3czsCF70pbxDrm/WbbN0kbE=.sha256",
+          "name": "audio:threshold_rc2.mp3",
+          "type": "audio/mpeg",
+          "size": 4027289
+        },
+        {
+          "link": "&gd+rghJZTGl5m5kuKtSXM9v/ndHP7RqXvXuRciLPkdg=.sha256",
+          "name": "A line drawing of the scott pilgrim movie poster",
+          "type": "image/jpeg",
+          "size": 201691
+        }
+      ]
+    },
+    "signature": "uuS90SXOx8/IsdKZrmoXa/dZohufvlq7L6XZ1it5nPkbqiU1wZB34jdKCuTYSY5qV+IU3uXxwR/2c20hY/KhDg==.sig.ed25519"
   }
 ]

--- a/test/output-inline.json
+++ b/test/output-inline.json
@@ -20,5 +20,7 @@
   "video:snow.mp4 video:snoooow.mp4 First birthday snow I've had since ~2012 or so. :)",
   "Hello... This is a text with three periods... twice.",
   "Hello.... This is a text with four periods.... twice.",
-  "Hey @MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519 check out my markdown parsing!"
+  "Hey @MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519 check out my markdown parsing!",
+  "Hey check out %9eJYIT1HDNhWOeLK0EhhiHJTPwvDGZWGd/E6CBCG5XY=.sha256 to see my mad ssb skillz!",
+  "Daan has the most amazing avatar go check it out at &amp;yao786uJVt042IiHj74vSZryrrP3U7tu1Lc6B+4CSLY=.sha256 yo."
 ]

--- a/test/output-inline.json
+++ b/test/output-inline.json
@@ -22,5 +22,6 @@
   "Hello.... This is a text with four periods.... twice.",
   "Hey @MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519 check out my markdown parsing!",
   "Hey check out %9eJYIT1HDNhWOeLK0EhhiHJTPwvDGZWGd/E6CBCG5XY=.sha256 to see my mad ssb skillz!",
-  "Daan has the most amazing avatar go check it out at &amp;yao786uJVt042IiHj74vSZryrrP3U7tu1Lc6B+4CSLY=.sha256 yo."
+  "Daan has the most amazing avatar go check it out at &amp;yao786uJVt042IiHj74vSZryrrP3U7tu1Lc6B+4CSLY=.sha256 yo.",
+  "@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519test"
 ]

--- a/test/output-inline.json
+++ b/test/output-inline.json
@@ -17,5 +17,7 @@
   "horizon.jpg",
   "Look at this thread: %70B9TI2hP5QMU59Lx9ozRD5Uh/E7tq4o1Ox8TP07XIg=.sha256",
   "Yeah yeah.... hitting publish prematurely.... Aaaaanyhow, since some people are not on dat and because I can, I'm dropping this off here, too. :) audio:threshold_rc2.mp3 A line drawing of the scott pilgrim movie poster\n",
-  "video:snow.mp4 video:snoooow.mp4 First birthday snow I've had since ~2012 or so. :)"
+  "video:snow.mp4 video:snoooow.mp4 First birthday snow I've had since ~2012 or so. :)",
+  "Hello... This is a text with three periods... twice.",
+  "Hello.... This is a text with four periods.... twice."
 ]

--- a/test/output-inline.json
+++ b/test/output-inline.json
@@ -19,5 +19,6 @@
   "Yeah yeah.... hitting publish prematurely.... Aaaaanyhow, since some people are not on dat and because I can, I'm dropping this off here, too. :) audio:threshold_rc2.mp3 A line drawing of the scott pilgrim movie poster\n",
   "video:snow.mp4 video:snoooow.mp4 First birthday snow I've had since ~2012 or so. :)",
   "Hello... This is a text with three periods... twice.",
-  "Hello.... This is a text with four periods.... twice."
+  "Hello.... This is a text with four periods.... twice.",
+  "Hey @MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519 check out my markdown parsing!"
 ]

--- a/test/output-inline.json
+++ b/test/output-inline.json
@@ -15,5 +15,6 @@
   "#轻拿轻放 #a-b+c.d #<span class=\"emoji\">🙃</span>",
   "",
   "horizon.jpg",
-  "Look at this thread: %70B9TI2hP5QMU59Lx9ozRD5Uh/E7tq4o1Ox8TP07XIg=.sha256"
+  "Look at this thread: %70B9TI2hP5QMU59Lx9ozRD5Uh/E7tq4o1Ox8TP07XIg=.sha256",
+  "Yeah yeah.... hitting publish prematurely.... Aaaaanyhow, since some people are not on dat and because I can, I'm dropping this off here, too. :) audio:threshold_rc2.mp3 A line drawing of the scott pilgrim movie poster\n"
 ]

--- a/test/output-inline.json
+++ b/test/output-inline.json
@@ -16,5 +16,6 @@
   "",
   "horizon.jpg",
   "Look at this thread: %70B9TI2hP5QMU59Lx9ozRD5Uh/E7tq4o1Ox8TP07XIg=.sha256",
-  "Yeah yeah.... hitting publish prematurely.... Aaaaanyhow, since some people are not on dat and because I can, I'm dropping this off here, too. :) audio:threshold_rc2.mp3 A line drawing of the scott pilgrim movie poster\n"
+  "Yeah yeah.... hitting publish prematurely.... Aaaaanyhow, since some people are not on dat and because I can, I'm dropping this off here, too. :) audio:threshold_rc2.mp3 A line drawing of the scott pilgrim movie poster\n",
+  "video:snow.mp4 video:snoooow.mp4 First birthday snow I've had since ~2012 or so. :)"
 ]

--- a/test/output.json
+++ b/test/output.json
@@ -20,7 +20,8 @@
   "<p><video src=\"/%26P5CAmVEEbJxlCRjcYaxzuE5%2FFOZ%2FlaDS5aOpTOm2MM0%3D.sha256\" alt=\"video:snow.mp4\" controls=\"undefined\"></p>\n<p><video src=\"/%26v7GopcAhKSsjmkA%2BA%2Fuf1w3sn10CLMR%2BeLhl6AWxMnM%3D.sha256\" alt=\"video:snoooow.mp4\" controls=\"undefined\"></p>\n<p>First birthday snow I’ve had since ~2012 or so. :)</p>\n",
   "<p>Hello… This is a text with three periods… twice.</p>\n",
   "<p>Hello… This is a text with four periods… twice.</p>\n",
-  "<p>Hey <a href=\"#/profile/%40MRiJ%2BCvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s%3D.ed25519\">@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519</a> check out my markdown parsing!</p>\n"
-
+  "<p>Hey <a href=\"#/profile/%40MRiJ%2BCvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s%3D.ed25519\">@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519</a> check out my markdown parsing!</p>\n",
+  "<p>Hey check out <a href=\"#/msg/%259eJYIT1HDNhWOeLK0EhhiHJTPwvDGZWGd%2FE6CBCG5XY%3D.sha256\">%9eJYI...</a> to see my mad ssb skillz!</p>\n",
+  "<p>Daan has the most amazing avatar go check it out at <a href=\"/%26yao786uJVt042IiHj74vSZryrrP3U7tu1Lc6B%2B4CSLY%3D.sha256\">&amp;yao786u...</a> yo.</p>\n"
 ]
 

--- a/test/output.json
+++ b/test/output.json
@@ -16,6 +16,7 @@
   "<p><img src=\"\" alt=\"\"></p>\n",
   "<p><img src=\"/%26RKIo6y4ARizHDPKOo00aiFCRyUtO9lBcr8O2fOmOk6I%3D.sha256%3Funbox%3DLOLyeahrightNotGoingToHappen%3D.boxs\" alt=\"horizon.jpg\"></p>\n",
   "<p>Look at this thread: <a href=\"#/msg/%2570B9TI2hP5QMU59Lx9ozRD5Uh%2FE7tq4o1Ox8TP07XIg%3D.sha256\">%70B9T...</a></p>\n",
-  "<p>Yeah yeah… hitting publish prematurely…<br>\nAaaaanyhow, since some people are not on dat and because I can, I’m dropping this off here, too. :)</p>\n<p><audio src=\"/%260vj4Oc8AnHAgOpFkikoB3czsCF70pbxDrm%2FWbbN0kbE%3D.sha256\" alt=\"audio:threshold_rc2.mp3\" controls=\"undefined\"></p>\n<p><img src=\"/%26gd%2BrghJZTGl5m5kuKtSXM9v%2FndHP7RqXvXuRciLPkdg%3D.sha256\" alt=\"A line drawing of the scott pilgrim movie poster\"></p>\n"
+  "<p>Yeah yeah… hitting publish prematurely…<br>\nAaaaanyhow, since some people are not on dat and because I can, I’m dropping this off here, too. :)</p>\n<p><audio src=\"/%260vj4Oc8AnHAgOpFkikoB3czsCF70pbxDrm%2FWbbN0kbE%3D.sha256\" alt=\"audio:threshold_rc2.mp3\" controls=\"undefined\"></p>\n<p><img src=\"/%26gd%2BrghJZTGl5m5kuKtSXM9v%2FndHP7RqXvXuRciLPkdg%3D.sha256\" alt=\"A line drawing of the scott pilgrim movie poster\"></p>\n",
+  "<p><video src=\"/%26P5CAmVEEbJxlCRjcYaxzuE5%2FFOZ%2FlaDS5aOpTOm2MM0%3D.sha256\" alt=\"video:snow.mp4\" controls=\"undefined\"></p>\n<p><video src=\"/%26v7GopcAhKSsjmkA%2BA%2Fuf1w3sn10CLMR%2BeLhl6AWxMnM%3D.sha256\" alt=\"video:snoooow.mp4\" controls=\"undefined\"></p>\n<p>First birthday snow I’ve had since ~2012 or so. :)</p>\n"
 ]
 

--- a/test/output.json
+++ b/test/output.json
@@ -15,6 +15,7 @@
   "<p><a href=\"#/channel/轻拿轻放\">#轻拿轻放</a> <a href=\"#/channel/a-b+c\">#a-b+c</a>.d <a href=\"#/channel/%F0%9F%99%83\">#<span class=\"emoji\">🙃</span></a></p>\n",
   "<p><img src=\"\" alt=\"\"></p>\n",
   "<p><img src=\"/%26RKIo6y4ARizHDPKOo00aiFCRyUtO9lBcr8O2fOmOk6I%3D.sha256%3Funbox%3DLOLyeahrightNotGoingToHappen%3D.boxs\" alt=\"horizon.jpg\"></p>\n",
-  "<p>Look at this thread: <a href=\"#/msg/%2570B9TI2hP5QMU59Lx9ozRD5Uh%2FE7tq4o1Ox8TP07XIg%3D.sha256\">%70B9T...</a></p>\n"
+  "<p>Look at this thread: <a href=\"#/msg/%2570B9TI2hP5QMU59Lx9ozRD5Uh%2FE7tq4o1Ox8TP07XIg%3D.sha256\">%70B9T...</a></p>\n",
+  "<p>Yeah yeah… hitting publish prematurely…<br>\nAaaaanyhow, since some people are not on dat and because I can, I’m dropping this off here, too. :)</p>\n<p><audio src=\"/%260vj4Oc8AnHAgOpFkikoB3czsCF70pbxDrm%2FWbbN0kbE%3D.sha256\" alt=\"audio:threshold_rc2.mp3\" controls=\"undefined\"></p>\n<p><img src=\"/%26gd%2BrghJZTGl5m5kuKtSXM9v%2FndHP7RqXvXuRciLPkdg%3D.sha256\" alt=\"A line drawing of the scott pilgrim movie poster\"></p>\n"
 ]
 

--- a/test/output.json
+++ b/test/output.json
@@ -22,6 +22,6 @@
   "<p>Hello… This is a text with four periods… twice.</p>\n",
   "<p>Hey <a href=\"#/profile/%40MRiJ%2BCvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s%3D.ed25519\">@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519</a> check out my markdown parsing!</p>\n",
   "<p>Hey check out <a href=\"#/msg/%259eJYIT1HDNhWOeLK0EhhiHJTPwvDGZWGd%2FE6CBCG5XY%3D.sha256\">%9eJYI...</a> to see my mad ssb skillz!</p>\n",
-  "<p>Daan has the most amazing avatar go check it out at <a href=\"/%26yao786uJVt042IiHj74vSZryrrP3U7tu1Lc6B%2B4CSLY%3D.sha256\">&amp;yao786u...</a> yo.</p>\n"
-]
+  "<p>Daan has the most amazing avatar go check it out at <a href=\"/%26yao786uJVt042IiHj74vSZryrrP3U7tu1Lc6B%2B4CSLY%3D.sha256\">&amp;yao786u...</a> yo.</p>\n",
+  "<p><a href=\"#/profile/%40MRiJ%2BCvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s%3D.ed25519\">@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519</a>test</p>\n" ]
 

--- a/test/output.json
+++ b/test/output.json
@@ -19,6 +19,8 @@
   "<p>Yeah yeah… hitting publish prematurely…<br>\nAaaaanyhow, since some people are not on dat and because I can, I’m dropping this off here, too. :)</p>\n<p><audio src=\"/%260vj4Oc8AnHAgOpFkikoB3czsCF70pbxDrm%2FWbbN0kbE%3D.sha256\" alt=\"audio:threshold_rc2.mp3\" controls=\"undefined\"></p>\n<p><img src=\"/%26gd%2BrghJZTGl5m5kuKtSXM9v%2FndHP7RqXvXuRciLPkdg%3D.sha256\" alt=\"A line drawing of the scott pilgrim movie poster\"></p>\n",
   "<p><video src=\"/%26P5CAmVEEbJxlCRjcYaxzuE5%2FFOZ%2FlaDS5aOpTOm2MM0%3D.sha256\" alt=\"video:snow.mp4\" controls=\"undefined\"></p>\n<p><video src=\"/%26v7GopcAhKSsjmkA%2BA%2Fuf1w3sn10CLMR%2BeLhl6AWxMnM%3D.sha256\" alt=\"video:snoooow.mp4\" controls=\"undefined\"></p>\n<p>First birthday snow I’ve had since ~2012 or so. :)</p>\n",
   "<p>Hello… This is a text with three periods… twice.</p>\n",
-  "<p>Hello… This is a text with four periods… twice.</p>\n"
+  "<p>Hello… This is a text with four periods… twice.</p>\n",
+  "<p>Hey <a href=\"#/profile/%40MRiJ%2BCvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s%3D.ed25519\">@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519</a> check out my markdown parsing!</p>\n"
+
 ]
 

--- a/test/output.json
+++ b/test/output.json
@@ -17,6 +17,8 @@
   "<p><img src=\"/%26RKIo6y4ARizHDPKOo00aiFCRyUtO9lBcr8O2fOmOk6I%3D.sha256%3Funbox%3DLOLyeahrightNotGoingToHappen%3D.boxs\" alt=\"horizon.jpg\"></p>\n",
   "<p>Look at this thread: <a href=\"#/msg/%2570B9TI2hP5QMU59Lx9ozRD5Uh%2FE7tq4o1Ox8TP07XIg%3D.sha256\">%70B9T...</a></p>\n",
   "<p>Yeah yeah… hitting publish prematurely…<br>\nAaaaanyhow, since some people are not on dat and because I can, I’m dropping this off here, too. :)</p>\n<p><audio src=\"/%260vj4Oc8AnHAgOpFkikoB3czsCF70pbxDrm%2FWbbN0kbE%3D.sha256\" alt=\"audio:threshold_rc2.mp3\" controls=\"undefined\"></p>\n<p><img src=\"/%26gd%2BrghJZTGl5m5kuKtSXM9v%2FndHP7RqXvXuRciLPkdg%3D.sha256\" alt=\"A line drawing of the scott pilgrim movie poster\"></p>\n",
-  "<p><video src=\"/%26P5CAmVEEbJxlCRjcYaxzuE5%2FFOZ%2FlaDS5aOpTOm2MM0%3D.sha256\" alt=\"video:snow.mp4\" controls=\"undefined\"></p>\n<p><video src=\"/%26v7GopcAhKSsjmkA%2BA%2Fuf1w3sn10CLMR%2BeLhl6AWxMnM%3D.sha256\" alt=\"video:snoooow.mp4\" controls=\"undefined\"></p>\n<p>First birthday snow I’ve had since ~2012 or so. :)</p>\n"
+  "<p><video src=\"/%26P5CAmVEEbJxlCRjcYaxzuE5%2FFOZ%2FlaDS5aOpTOm2MM0%3D.sha256\" alt=\"video:snow.mp4\" controls=\"undefined\"></p>\n<p><video src=\"/%26v7GopcAhKSsjmkA%2BA%2Fuf1w3sn10CLMR%2BeLhl6AWxMnM%3D.sha256\" alt=\"video:snoooow.mp4\" controls=\"undefined\"></p>\n<p>First birthday snow I’ve had since ~2012 or so. :)</p>\n",
+  "<p>Hello… This is a text with three periods… twice.</p>\n",
+  "<p>Hello… This is a text with four periods… twice.</p>\n"
 ]
 

--- a/test/test-names.json
+++ b/test/test-names.json
@@ -1,0 +1,19 @@
+[
+  "message with link",
+  "message with image",
+  "message with '@' mentions",
+  "message with emoji",
+  "message with ascii emoji",
+  "message with inline html in code block",
+  "message with hashtag",
+  "message with customs protocols",
+  "message with links, mentions, headers, and code",
+  "message with both emoji and :shortcodes:",
+  "message with compound emoji",
+  "message with node-emoji shortcodes",
+  "message with sigil links in proper Markdown",
+  "message with non-ASCII unicode hashtag",
+  "message with external image",
+  "message with private image",
+  "message with %70 link"
+]

--- a/test/test-names.json
+++ b/test/test-names.json
@@ -17,5 +17,7 @@
   "message with private image",
   "message with %70 link",
   "message with embedded audio file",
-  "message with embedded video file"
+  "message with embedded video file",
+  "message with three consecutive periods",
+  "message with four consecutive periods"
 ]

--- a/test/test-names.json
+++ b/test/test-names.json
@@ -22,5 +22,6 @@
   "message with four consecutive periods",
   "message with raw @feed mention",
   "message with raw %message mention",
-  "message with raw &blob mention"
+  "message with raw &blob mention",
+  "message with feed id mangled with text"
 ]

--- a/test/test-names.json
+++ b/test/test-names.json
@@ -15,5 +15,6 @@
   "message with non-ASCII unicode hashtag",
   "message with external image",
   "message with private image",
-  "message with %70 link"
+  "message with %70 link",
+  "message with embedded audio file"
 ]

--- a/test/test-names.json
+++ b/test/test-names.json
@@ -20,5 +20,7 @@
   "message with embedded video file",
   "message with three consecutive periods",
   "message with four consecutive periods",
-  "message with raw @feed mention"
+  "message with raw @feed mention",
+  "message with raw %message mention",
+  "message with raw &blob mention"
 ]

--- a/test/test-names.json
+++ b/test/test-names.json
@@ -19,5 +19,6 @@
   "message with embedded audio file",
   "message with embedded video file",
   "message with three consecutive periods",
-  "message with four consecutive periods"
+  "message with four consecutive periods",
+  "message with raw @feed mention"
 ]

--- a/test/test-names.json
+++ b/test/test-names.json
@@ -16,5 +16,6 @@
   "message with external image",
   "message with private image",
   "message with %70 link",
-  "message with embedded audio file"
+  "message with embedded audio file",
+  "message with embedded video file"
 ]


### PR DESCRIPTION
In the process of using this library I added a few tests to better understand how to use it.
One of them fails. :)

The error is produced by omitting a space after a mention: `@MRiJ+CvDnD9ZjqunY1oy6tsk0IdbMDC4Q3tTC8riS3s=.ed25519test`

This could be ham-fistedly resolved by replacing `sigilRegExp` in `block.js`:
```javascript
const sigilRegExp = new RegExp(/^[a-zA-Z0-9+/=]{44}\.(sha256|ed25519)/)
```
The benefit is that it fixes this situation. The drawback is that it is specific to the sigil links we have at the moment. Not exactly a huge problem _for now_ and easy to fix (by just giving a list of known suffixes) later on. But still a bit iffy.